### PR TITLE
Support writing .vtp files

### DIFF
--- a/pymskt/mesh/io.py
+++ b/pymskt/mesh/io.py
@@ -77,8 +77,12 @@ def write_vtk(mesh, filepath, scalar_name=None, points_dtype=float, write_binary
         writer = vtk.vtkSTLWriter()
     elif extension == ".obj":
         writer = vtk.vtkOBJWriter()
+    elif extension == ".vtp":
+        writer = vtk.vtkXMLPolyDataWriter()
     else:
-        raise ValueError(f"File extension {extension} not supported. Please use .vtk, .stl or .obj")
+        raise ValueError(
+            f"File extension {extension} not supported. Please use .vtk, .vtp, .stl or .obj"
+        )
 
     writer.SetFileName(filepath)
     writer.SetInputData(mesh)


### PR DESCRIPTION
This allows writing `.vtp`-format files, which are the successor to the legacy `.vtk` text-based format. The virtue of `.vtp` is that they're natively supported by vtk.js, whereas `.vtk` files are not.