### PR TITLE
Update: Superficial/deep cartilage, Mesh.copy, thickness calc, registration

### DIFF
--- a/pymskt/__init__.py
+++ b/pymskt/__init__.py
@@ -13,4 +13,4 @@ import pymskt.utils as utils
 RTOL = 1e-4
 ATOL = 1e-5
 
-__version__ = "0.1.02"
+__version__ = "0.1.03"

--- a/pymskt/__init__.py
+++ b/pymskt/__init__.py
@@ -13,4 +13,4 @@ import pymskt.utils as utils
 RTOL = 1e-4
 ATOL = 1e-5
 
-__version__ = "0.1.01"
+__version__ = "0.1.02"

--- a/pymskt/mesh/anatomical/femur_cylinder.py
+++ b/pymskt/mesh/anatomical/femur_cylinder.py
@@ -54,7 +54,7 @@ class FitCylinderFemur:
         self.guess_radius()
 
     def get_articular_surf_points(self):
-        label_idx = self.femur.point_data["self.labels_name"]
+        label_idx = self.femur.point_data[self.labels_name]
         cylinder_labels = label_idx == self.labels[0]
         if len(self.labels) > 1:
             for idx in range(1, len(self.labels)):

--- a/pymskt/mesh/meshCartilage.py
+++ b/pymskt/mesh/meshCartilage.py
@@ -301,7 +301,7 @@ def break_cartilage_into_superficial_deep(
     # if the cartilage meshes don't exist yet, create them.
     if bone_mesh.list_cartilage_meshes is None:
         bone_mesh.create_cartilage_meshes()
-    
+
     orig_cart_meshes = [cart_mesh_.copy() for cart_mesh_ in bone_mesh.list_cartilage_meshes]
 
     # if the cartilage surfaces are not resampled yet, and we want them to be,
@@ -313,10 +313,10 @@ def break_cartilage_into_superficial_deep(
     # if the articular surfaces don't exist yet, create them.
     if bone_mesh.list_articular_surfaces is None:
         bone_mesh.extract_articular_surfaces()
-    
+
     # re-assign the full resolution cartilage meshes to the bone_mesh object.
     bone_mesh.list_cartilage_meshes = orig_cart_meshes
-    
+
     # convert the seg_image to a numpy array, and get the voxel locations of the
     # cartilage labels.
     seg_arr = sitk.GetArrayFromImage(seg_image)

--- a/pymskt/mesh/meshCartilage.py
+++ b/pymskt/mesh/meshCartilage.py
@@ -301,6 +301,8 @@ def break_cartilage_into_superficial_deep(
     # if the cartilage meshes don't exist yet, create them.
     if bone_mesh.list_cartilage_meshes is None:
         bone_mesh.create_cartilage_meshes()
+    
+    orig_cart_meshes = [cart_mesh_.copy() for cart_mesh_ in bone_mesh.list_cartilage_meshes]
 
     # if the cartilage surfaces are not resampled yet, and we want them to be,
     # do that now.
@@ -311,7 +313,10 @@ def break_cartilage_into_superficial_deep(
     # if the articular surfaces don't exist yet, create them.
     if bone_mesh.list_articular_surfaces is None:
         bone_mesh.extract_articular_surfaces()
-
+    
+    # re-assign the full resolution cartilage meshes to the bone_mesh object.
+    bone_mesh.list_cartilage_meshes = orig_cart_meshes
+    
     # convert the seg_image to a numpy array, and get the voxel locations of the
     # cartilage labels.
     seg_arr = sitk.GetArrayFromImage(seg_image)

--- a/pymskt/mesh/meshRegistration.py
+++ b/pymskt/mesh/meshRegistration.py
@@ -1,7 +1,8 @@
 import sys
+
 import cycpd
-import vtk
 import pyvista as pv
+import vtk
 
 from pymskt.mesh.meshTools import transfer_mesh_scalars_get_weighted_average_n_closest
 
@@ -62,10 +63,10 @@ def get_icp_transform(source, target, max_n_iter=1000, n_landmarks=1000, reg_mod
 def cpd_register(
     target_mesh,
     source_mesh,
-    reg_type='non_rigid',
+    reg_type="non_rigid",
     max_iterations=1_000,
-    alpha=1, #0.1
-    beta=7, #3
+    alpha=1,  # 0.1
+    beta=7,  # 3
     num_eig=100,
     n_samples=1_000,
     icp_register_first=True,  # Get bones/objects into roughly the same alignment first
@@ -77,10 +78,10 @@ def cpd_register(
     return_icp_transform=False,
 ):
     from pymskt.mesh import Mesh
-    
+
     assert isinstance(target_mesh, Mesh), "target_mesh must be inherited from pymskt.mesh.Mesh"
     assert isinstance(source_mesh, Mesh), "source_mesh must be inherited from pymskt.mesh.Mesh"
-    
+
     if icp_register_first is True:
         if icp_reg_target_to_source is True:
             icp_source = source_mesh.copy()
@@ -88,13 +89,12 @@ def cpd_register(
         else:
             icp_source = target_mesh.copy()
             icp_target = source_mesh.copy()
-            
-        
-        print('icp_source')
+
+        print("icp_source")
         print(icp_source)
-        print('icp_target')
+        print("icp_target")
         print(icp_target)
-        
+
         icp_source = icp_source.rigidly_register(
             other_mesh=icp_target,
             as_source=True,
@@ -103,51 +103,54 @@ def cpd_register(
             return_transform=False,
             max_n_iter=icp_iterations,
             n_landmarks=icp_n_landmarks,
-            reg_mode=icp_registration_mode
+            reg_mode=icp_registration_mode,
         )
-        
-        print('icp_source')
+
+        print("icp_source")
         print(icp_source)
-        
+
         if icp_reg_target_to_source is True:
             source_mesh = icp_source
         else:
             target_mesh = icp_source
-    
+
     if n_samples is not None:
         rand_idxs_source = np.random.choice(source_mesh.points.shape[0], n_samples, replace=False)
         rand_idxs_target = np.random.choice(target_mesh.points.shape[0], n_samples, replace=False)
-    
-    if reg_type == 'non_rigid':
+
+    if reg_type == "non_rigid":
         reg = cycpd.deformable_registration(
-            X=np.asarray(target_mesh.points if n_samples is None else target_mesh.points[rand_idxs_target,:]),
-            Y=np.asarray(source_mesh.points if n_samples is None else source_mesh.points[rand_idxs_source,:]),
+            X=np.asarray(
+                target_mesh.points if n_samples is None else target_mesh.points[rand_idxs_target, :]
+            ),
+            Y=np.asarray(
+                source_mesh.points if n_samples is None else source_mesh.points[rand_idxs_source, :]
+            ),
             max_iterations=max_iterations,
             alpha=alpha,
             beta=beta,
             num_eig=num_eig,
             tolerance=1e-5,
-            
         )
-    elif reg_type == 'rigid':
+    elif reg_type == "rigid":
         # if rigid, then we can turn the result into the vtk transform
-        # on the other side of things. 
+        # on the other side of things.
         raise NotImplementedError("Rigid registration not implemented yet")
-    elif reg_type == 'affine':
+    elif reg_type == "affine":
         raise NotImplementedError("Affine registration not implemented yet")
     else:
         raise ValueError(f"Registration type {reg_type} not recognized")
 
     transformed_source, reg_params = reg.register()
-    
+
     if n_samples is not None:
         transformed_source = reg.transform_point_cloud(source_mesh.points)
-    
+
     source_mesh.points = transformed_source
-    
-    print('source_mesh')
+
+    print("source_mesh")
     print(source_mesh)
-    
+
     if transfer_scalars is True:
         source_mesh = transfer_mesh_scalars_get_weighted_average_n_closest(
             source_mesh,
@@ -156,14 +159,15 @@ def cpd_register(
             return_mesh=True,
             create_new_mesh=True,
         )
-    
-    print('source_mesh')
+
+    print("source_mesh")
     print(source_mesh)
 
     # if return_icp_transform is True:
     #     return mesh_transformed_to_target, reg.icp_transform
-    
+
     return source_mesh, reg_params
+
 
 def non_rigidly_register(
     target_mesh=None,

--- a/pymskt/mesh/meshes.py
+++ b/pymskt/mesh/meshes.py
@@ -23,7 +23,7 @@ from pymskt.mesh.meshCartilage import (
     break_cartilage_into_superficial_deep,
     extract_articular_surface,
 )
-from pymskt.mesh.meshRegistration import get_icp_transform, non_rigidly_register, cpd_register
+from pymskt.mesh.meshRegistration import cpd_register, get_icp_transform, non_rigidly_register
 from pymskt.mesh.meshTools import (
     compute_assd_between_point_clouds,
     consistent_normals,
@@ -542,7 +542,7 @@ class Mesh(pv.PolyData):
         as_source=True,
         apply_transform_to_mesh=True,
         return_transformed_mesh=False,
-        reg_method='focusr', # alternatively 'cpd'
+        reg_method="focusr",  # alternatively 'cpd'
         **kwargs,
     ):
         """
@@ -571,20 +571,20 @@ class Mesh(pv.PolyData):
         elif as_source is False:
             source = other_mesh
             target = self
-        
-        if reg_method == 'focusr':
-            print('Using focusr for registration')
+
+        if reg_method == "focusr":
+            print("Using focusr for registration")
             # Get registered mesh (source to target)
             source_transformed_to_target = non_rigidly_register(
                 target_mesh=target, source_mesh=source, **kwargs
             )
-        elif reg_method == 'cpd':
-            print('Using cpd for registration')
+        elif reg_method == "cpd":
+            print("Using cpd for registration")
             source_transformed_to_target, reg_params = cpd_register(
                 target_mesh=target.copy(), source_mesh=source.copy(), **kwargs
             )
-        
-        print('source_transformed_to_target')
+
+        print("source_transformed_to_target")
         print(source_transformed_to_target)
 
         # If current mesh is source & apply_transform_to_mesh is true then replace current mesh.
@@ -1653,16 +1653,16 @@ class BoneMesh(Mesh):
         """
         region_array = self.get_scalar("labels")
         thickness_array = self.get_scalar("thickness (mm)")
-        
+
         data = thickness_array[region_array == region_idx]
         if len(data) == 0:
             # print warning
             warnings.warn(f"No data for region {region_idx} - returning mean as nan", UserWarning)
-            print(f'Unique labels: {np.unique(region_array)}, region_idx: {region_idx}')
+            print(f"Unique labels: {np.unique(region_array)}, region_idx: {region_idx}")
             mean = np.nan
         else:
-            # convert to array to avoid runtime errors: 
-            #RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
+            # convert to array to avoid runtime errors:
+            # RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
             mean = np.nanmean(np.array(data))
 
         return mean
@@ -1683,16 +1683,16 @@ class BoneMesh(Mesh):
         """
         region_array = self.get_scalar("labels")
         thickness_array = self.get_scalar("thickness (mm)")
-        
+
         data = thickness_array[region_array == region_idx]
         if len(data) == 0:
             # print warning
             warnings.warn(f"No data for region {region_idx} - returning std as nan", UserWarning)
-            print(f'Unique labels: {np.unique(region_array)}, region_idx: {region_idx}')
+            print(f"Unique labels: {np.unique(region_array)}, region_idx: {region_idx}")
             std = np.nan
         else:
-            # convert to array to avoid runtime errors: 
-            #RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
+            # convert to array to avoid runtime errors:
+            # RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
             std = np.nanstd(np.array(data))
 
         return std
@@ -1722,12 +1722,14 @@ class BoneMesh(Mesh):
         data = thickness_array[region_array == region_idx]
         if len(data) == 0:
             # print warning
-            warnings.warn(f"No data for region {region_idx} - returning percentile as nan", UserWarning)
-            print(f'Unique labels: {np.unique(region_array)}, region_idx: {region_idx}')
+            warnings.warn(
+                f"No data for region {region_idx} - returning percentile as nan", UserWarning
+            )
+            print(f"Unique labels: {np.unique(region_array)}, region_idx: {region_idx}")
             percentile = np.nan
         else:
-            # convert to array to avoid runtime errors: 
-            #RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
+            # convert to array to avoid runtime errors:
+            # RuntimeError: ndarray subclass __array_wrap__ method returned an object which was not an instance of an ndarray subclass
 
             percentile = np.percentile(np.array(data), percentile)
 

--- a/pymskt/mesh/meshes.py
+++ b/pymskt/mesh/meshes.py
@@ -145,7 +145,7 @@ class Mesh(pv.PolyData):
         if self.n_points > 0:
             self.load_mesh_scalars()
 
-    def copy(self):
+    def copy(self, deep=True):
         """
         Create a copy of the mesh object.
 
@@ -155,7 +155,7 @@ class Mesh(pv.PolyData):
             A copy of the mesh object
         """
 
-        copy_ = super().copy(deep=True)
+        copy_ = super().copy(deep=deep)
         copy_.seg_image = self._seg_image
         copy_.path_seg_image = self._path_seg_image
         copy_.label_idx = self._label_idx
@@ -1302,7 +1302,7 @@ class BoneMesh(Mesh):
             min_n_pixels=min_n_pixels,
         )
 
-    def copy(self):
+    def copy(self, deep=True):
         """
         Copy the current mesh object.
 
@@ -1311,7 +1311,7 @@ class BoneMesh(Mesh):
         BoneMesh
             A copy of the current mesh object.
         """
-        copy_ = super().copy()
+        copy_ = super().copy(deep=deep)
         copy_.crop_percent = self.crop_percent
         copy_.bone = self.bone
         copy_.list_cartilage_meshes = self.list_cartilage_meshes


### PR DESCRIPTION
- Superficial/deep resampled cart surfaces in bone object as interim step. We new restore the cartilage surfaces to original versions (resolution). 
- Mesh.copy caused issues with pyvist PolyData - fixed. 
- mean thickness calculations had issues with nan mean calculation due to array being a pyvist numpy array - a derivative of numpy array. Fixed. 
- added other types of non-rigid registration (cpd). 