### PR TITLE
Improve scalar transfer to support categorical labels 

### DIFF
--- a/pymskt/__init__.py
+++ b/pymskt/__init__.py
@@ -12,4 +12,4 @@ import pymskt.utils as utils
 
 RTOL = 1e-4
 ATOL = 1e-5
-__version__ = "0.1.16"
+__version__ = "0.1.17"

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -3,7 +3,6 @@ import point_cloud_utils as pcu
 import pyacvd
 import pymeshfix as mf
 import pyvista as pv
-import scipy.stats
 import vtk
 from scipy.spatial import cKDTree
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -692,7 +692,7 @@ def smooth_scalars_from_second_mesh_onto_base(
 
 
 def transfer_mesh_scalars_get_weighted_average_n_closest(
-    new_mesh, old_mesh, n=3, return_mesh=False, create_new_mesh=False, max_dist=None, categorical=False
+    new_mesh, old_mesh, n=3, return_mesh=False, create_new_mesh=False, max_dist=None, categorical=None
 ):
     """
     Transfer scalars from old_mesh to new_mesh using the weighted-average of the `n` closest
@@ -712,6 +712,10 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         `smooth_scalars_from_second_mesh_onto_base`
     n : int, optional
         The number of closest nodes that we want to get weighed average of, by default 3
+    categorical : bool, dict, or None, optional
+        Specify whether scalars should be treated as categorical. If None (default), 
+        auto-detects based on data type per array. If bool, applies to all arrays.
+        If dict, keys should be array names with bool values.
 
     Returns
     -------
@@ -719,6 +723,7 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         A dict of the scalar values with keys = scalar names and the scalar value for
         each node that includes the scalar values transfered (smoothed) from the `old_mesh`.
     """
+    from collections import defaultdict
 
     kDTree = vtk.vtkKdTreePointLocator()
     kDTree.SetDataSet(old_mesh)
@@ -735,6 +740,28 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         np.copy(vtk_to_numpy(old_mesh.GetPointData().GetArray(array_name)))
         for array_name in array_names
     ]
+    
+    # Handle categorical parameter - auto-detect if None, or create per-array flags
+    if categorical is None:
+        # Auto-detect categorical for each array based on data type
+        categorical_flags = {}
+        for array_name in array_names:
+            arr = vtk_to_numpy(old_mesh.GetPointData().GetArray(array_name))
+            categorical_flags[array_name] = np.issubdtype(arr.dtype, np.integer)
+    elif isinstance(categorical, bool):
+        # Apply same categorical flag to all arrays
+        categorical_flags = {array_name: categorical for array_name in array_names}
+    elif isinstance(categorical, dict):
+        # Use provided per-array flags
+        categorical_flags = categorical.copy()
+        # Fill in missing arrays with auto-detection
+        for array_name in array_names:
+            if array_name not in categorical_flags:
+                arr = vtk_to_numpy(old_mesh.GetPointData().GetArray(array_name))
+                categorical_flags[array_name] = np.issubdtype(arr.dtype, np.integer)
+    else:
+        raise ValueError("categorical must be None, bool, or dict")
+    
     # print('len scalars_old_mesh', len(scalars_old_mesh))
     # scalars_old_mesh = np.copy(vtk_to_numpy(old_mesh.GetPointData().GetScalars()))
     for new_mesh_pt_idx in range(new_mesh.GetNumberOfPoints()):
@@ -758,28 +785,30 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
             # no points within max_dist, skip (which leaves the scalar(s) at zero)
             continue
         
-        if categorical:
-            # Mode along each array (each label array for this new point)
-            arr = np.asarray(list_scalars)
-            # mode returns mode value and count, axis=0 gets mode for each array_name
-            mode_vals, _ = scipy.stats.mode(arr, axis=0, keepdims=False)
-            for array_idx, array_name in enumerate(array_names):
-                new_scalars[array_name][new_mesh_pt_idx] = mode_vals[0, array_idx] if mode_vals.ndim > 1 else mode_vals[array_idx]
-        else:
-            total_distance = np.sum(distance_weighting)
-            normalized_value = (
-                np.sum(
-                    np.asarray(list_scalars) * np.expand_dims(np.asarray(distance_weighting), axis=1),
-                    axis=0,
+        # Process each array individually based on its categorical flag
+        arr = np.asarray(list_scalars)
+        for array_idx, array_name in enumerate(array_names):
+            if categorical_flags[array_name]:
+                # Distance-weighted voting for categorical data
+                array_values = arr[:, array_idx]
+                if len(array_values) > 0:
+                    label_weights = defaultdict(float)
+                    for label, weight in zip(array_values, distance_weighting):
+                        label_weights[int(label)] += weight
+                    chosen_label = max(label_weights, key=label_weights.get)
+                    new_scalars[array_name][new_mesh_pt_idx] = chosen_label
+            else:
+                # Weighted average for continuous data
+                total_distance = np.sum(distance_weighting)
+                normalized_value = (
+                    np.sum(arr[:, array_idx] * np.asarray(distance_weighting)) / total_distance
                 )
-                / total_distance
-            )
-            for array_idx, array_name in enumerate(array_names):
-                new_scalars[array_name][new_mesh_pt_idx] = normalized_value[array_idx]
+                new_scalars[array_name][new_mesh_pt_idx] = normalized_value
 
     if return_mesh is False:
-        if categorical:
-            for array_name in new_scalars:
+        # Convert only categorical arrays to int, preserve float arrays as float
+        for array_name in array_names:
+            if categorical_flags[array_name]:
                 new_scalars[array_name] = new_scalars[array_name].astype(int)
         return new_scalars
     else:
@@ -790,6 +819,9 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
             # this just makes a reference to the existing new_mesh in memory.
             new_mesh_ = new_mesh
         for array_name, scalars in new_scalars.items():
+            # Convert only categorical arrays to int before creating VTK array
+            if categorical_flags[array_name]:
+                scalars = scalars.astype(int)
             new_array = numpy_to_vtk(scalars)
             new_array.SetName(array_name)
             new_mesh_.GetPointData().AddArray(new_array)

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -730,7 +730,6 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         A dict of the scalar values with keys = scalar names and the scalar value for
         each node that includes the scalar values transfered (smoothed) from the `old_mesh`.
     """
-    from collections import defaultdict
 
     kDTree = vtk.vtkKdTreePointLocator()
     kDTree.SetDataSet(old_mesh)

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -789,6 +789,8 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         if len(list_scalars) == 0:
             # no points within max_dist, skip (which leaves the scalar(s) at zero)
             continue
+        # compute the total distance
+        total_distance = np.sum(distance_weighting)
 
         # Process each array individually based on its categorical flag
         arr = np.asarray(list_scalars)
@@ -804,7 +806,6 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
                     new_scalars[array_name][new_mesh_pt_idx] = chosen_label
             else:
                 # Weighted average for continuous data
-                total_distance = np.sum(distance_weighting)
                 normalized_value = (
                     np.sum(arr[:, array_idx] * np.asarray(distance_weighting)) / total_distance
                 )

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -3,10 +3,11 @@ import point_cloud_utils as pcu
 import pyacvd
 import pymeshfix as mf
 import pyvista as pv
+import scipy.stats
 import vtk
 from scipy.spatial import cKDTree
 from vtk.util.numpy_support import numpy_to_vtk, vtk_to_numpy
-import scipy.stats
+
 from pymskt.mesh.utils import (
     get_intersect,
     get_obb_surface,
@@ -692,7 +693,13 @@ def smooth_scalars_from_second_mesh_onto_base(
 
 
 def transfer_mesh_scalars_get_weighted_average_n_closest(
-    new_mesh, old_mesh, n=3, return_mesh=False, create_new_mesh=False, max_dist=None, categorical=None
+    new_mesh,
+    old_mesh,
+    n=3,
+    return_mesh=False,
+    create_new_mesh=False,
+    max_dist=None,
+    categorical=None,
 ):
     """
     Transfer scalars from old_mesh to new_mesh using the weighted-average of the `n` closest
@@ -713,7 +720,7 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
     n : int, optional
         The number of closest nodes that we want to get weighed average of, by default 3
     categorical : bool, dict, or None, optional
-        Specify whether scalars should be treated as categorical. If None (default), 
+        Specify whether scalars should be treated as categorical. If None (default),
         auto-detects based on data type per array. If bool, applies to all arrays.
         If dict, keys should be array names with bool values.
 
@@ -740,7 +747,7 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         np.copy(vtk_to_numpy(old_mesh.GetPointData().GetArray(array_name)))
         for array_name in array_names
     ]
-    
+
     # Handle categorical parameter - auto-detect if None, or create per-array flags
     if categorical is None:
         # Auto-detect categorical for each array based on data type
@@ -761,7 +768,7 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
                 categorical_flags[array_name] = np.issubdtype(arr.dtype, np.integer)
     else:
         raise ValueError("categorical must be None, bool, or dict")
-    
+
     # print('len scalars_old_mesh', len(scalars_old_mesh))
     # scalars_old_mesh = np.copy(vtk_to_numpy(old_mesh.GetPointData().GetScalars()))
     for new_mesh_pt_idx in range(new_mesh.GetNumberOfPoints()):
@@ -784,7 +791,7 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         if len(list_scalars) == 0:
             # no points within max_dist, skip (which leaves the scalar(s) at zero)
             continue
-        
+
         # Process each array individually based on its categorical flag
         arr = np.asarray(list_scalars)
         for array_idx, array_name in enumerate(array_names):

--- a/pymskt/mesh/meshTools.py
+++ b/pymskt/mesh/meshTools.py
@@ -720,11 +720,6 @@ def transfer_mesh_scalars_get_weighted_average_n_closest(
         each node that includes the scalar values transfered (smoothed) from the `old_mesh`.
     """
 
-    if categorical is True:
-        print("categorical is True")
-    else:
-        print("categorical is False")
-
     kDTree = vtk.vtkKdTreePointLocator()
     kDTree.SetDataSet(old_mesh)
     kDTree.BuildLocator()

--- a/pymskt/mesh/meshes.py
+++ b/pymskt/mesh/meshes.py
@@ -687,7 +687,7 @@ class Mesh(pv.PolyData):
         idx_coords_to_smooth_base=None,
         idx_coords_to_smooth_other=None,
         set_non_smoothed_scalars_to_zero=True,
-        categorical=None, 
+        categorical=None,
     ):
         """
         Convenience function to enable easy transfer scalars from another mesh to the current.
@@ -720,7 +720,7 @@ class Mesh(pv.PolyData):
         set_non_smoothed_scalars_to_zero : bool, optional
             Should all other indices (not included in idx_coords_to_smooth_other) be set to 0, by default True
         categorical : bool, dict, list, or None, optional
-            Specify whether scalars should be treated as categorical. If None (default), 
+            Specify whether scalars should be treated as categorical. If None (default),
             auto-detects based on data type per array. If bool, applies to all scalars.
             If dict, keys should be scalar names with bool values.
             If list, should have same length as orig_scalars_name with bool values.
@@ -757,7 +757,7 @@ class Mesh(pv.PolyData):
             # Auto-detect categorical for each scalar being transferred
             categorical_flags = {}
             for scalar_name in orig_scalars_name:
-                if hasattr(other_mesh, 'point_data'):
+                if hasattr(other_mesh, "point_data"):
                     arr = other_mesh.point_data[scalar_name]
                 else:
                     arr = vtk_to_numpy(other_mesh.GetPointData().GetArray(scalar_name))
@@ -769,14 +769,17 @@ class Mesh(pv.PolyData):
             # List of categorical flags, one per scalar
             if len(categorical) != len(orig_scalars_name):
                 raise ValueError("categorical list must have same length as orig_scalars_name")
-            categorical_flags = {scalar_name: cat_flag for scalar_name, cat_flag in zip(orig_scalars_name, categorical)}
+            categorical_flags = {
+                scalar_name: cat_flag
+                for scalar_name, cat_flag in zip(orig_scalars_name, categorical)
+            }
         elif isinstance(categorical, dict):
             # Dictionary of categorical flags
             categorical_flags = categorical.copy()
             # Fill in missing scalars with auto-detection
             for scalar_name in orig_scalars_name:
                 if scalar_name not in categorical_flags:
-                    if hasattr(other_mesh, 'point_data'):
+                    if hasattr(other_mesh, "point_data"):
                         arr = other_mesh.point_data[scalar_name]
                     else:
                         arr = vtk_to_numpy(other_mesh.GetPointData().GetArray(scalar_name))


### PR DESCRIPTION
This request enhances scalar transfer to support categorical (integer) labels by using mode, with automatic type detection. Float scalars are handled as before with weighted average. Also ensures categorical arrays remain integer type in the output.