### PR TITLE
Clean up GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [ubuntu-latest]
         # only run linting on a single python version (a recent one that is used for development)
         python-version: ["3.11"]
     

--- a/.github/workflows/building-pypi-linux.yml
+++ b/.github/workflows/building-pypi-linux.yml
@@ -50,43 +50,8 @@ jobs:
           name: cibw-sdist
           path: ./wheelhouse/*.tar.gz
 
-  #BUILD WHEELS ONLY NEEDED FOR NON-PURE PYTHON PACKAGES
-  #This is described here: https://packaging.python.org/en/latest/overview/#python-binary-distributions
-  build_wheels:
-    name: Build wheels
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        # macos-14 = Apple Silicon (arm64) runner
-        # macos-14-large = Intel (x86_64) runner
-        # Updated from macos-13 due to deprecation (Dec 2025)
-        # Using macos-14 for arm64 wheels and macos-14-large for Intel wheels
-        os: [ubuntu-latest, windows-2022, macos-14, macos-14-large]
-    
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        name: Install Python
-        with:
-          python-version: '3.10'
-      
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.7.0
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-
-      # - name: Build wheels
-      #   uses: pypa/cibuildwheel@v2.2.2
-      
-      - uses: actions/upload-artifact@v4
-        with:
-            name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
-            path: ./wheelhouse/*.whl
-  
   upload_pypi:
-    needs: [build_sdist] #build_wheels
+    needs: [build_sdist]
     runs-on: ubuntu-latest
 
     steps:
@@ -97,7 +62,7 @@ jobs:
           path: dist
           merge-multiple: true
       
-      - uses: pypa/gh-action-pypi-publish@v1.4.2
+      - uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYMSKT_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- **pypi**: Remove unused `build_wheels` job (pymskt is pure Python, sdist is sufficient). Update `gh-action-pypi-publish` from v1.4.2 to v1.12.4
- **build-test**: Limit lint job to `ubuntu-latest` only (linting is platform-independent, saves macOS runner minutes)
- **docs**: Update `deploy-pages` from `@v1` to `@v4` (fixes artifact API mismatch that caused website deploy failures)

## Test plan
- [x] Verified `build_wheels` was dead code (upload_pypi only depends on build_sdist)
- [ ] Merge and confirm all three workflows pass on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)